### PR TITLE
Update to clean-css v3

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function (options) {
 					if (err) {
 						return cb(new gutil.PluginError('gulp-cssmin', err));
 					}
-					var minimized = new CleanCSS(options).minify(data);
+					var minimized = new CleanCSS(options).minify(data).styles;
 					if (options.showLog) {
 						gutil.log('gulp-cssmin:', gutil.colors.green('✔ ') + file.relative);
 					}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-cssmin",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "minify css using gulp",
   "main": "index.js",
   "scripts": {
@@ -18,7 +18,7 @@
     "filesize": "~2.0.0",
     "temp-write": "~0.1.0",
     "map-stream": "0.0.4",
-    "clean-css": "~3.1.9",
+    "clean-css": "^3.1.9",
     "gulp-rename": "~1.1.0"
   },
   "author": "chilijung",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "filesize": "~2.0.0",
     "temp-write": "~0.1.0",
     "map-stream": "0.0.4",
-    "clean-css": "~2.2.1",
+    "clean-css": "~3.1.9",
     "gulp-rename": "~1.1.0"
   },
   "author": "chilijung",


### PR DESCRIPTION
Includes a number of bug fixes and new features. Also switched to the caret (`^`) operator so that we’ll get future minor versions that include new features, instead of just patch versions.

I’ve bumped the minor version number for this package, but I equally could (should?) bump the major version number instead (as there are [one or two “breaking” changes](https://github.com/jakubpawlowicz/clean-css#how-to-upgrade-clean-css-from-2x-to-3x) in clean-css v3).

I’m happy to squash the commits too if that’s preferred.