### PR TITLE
update graceful-fs to 4.1.4, graceful-fs v3.0.0 and before is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "gulp-util": "~2.2.0",
-    "graceful-fs": "~2.0.0",
+    "graceful-fs": "~4.1.4",
     "filesize": "~2.0.0",
     "temp-write": "~0.1.0",
     "map-stream": "0.0.4",


### PR DESCRIPTION
deprecate: graceful-fs v3.0.0 and before will fail on node releases >= v7.0.
