### PR TITLE
Bump clean-css version to 4.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   "dependencies": {
     "gulp-util": "~2.2.0",
     "graceful-fs": "~4.1.4",
+    "clean-css": "^4.1.3",
     "filesize": "~2.0.0",
     "temp-write": "~0.1.0",
     "map-stream": "0.0.4",
-    "clean-css": "^3.1.9",
     "gulp-rename": "~1.1.0"
   },
   "author": "chilijung",


### PR DESCRIPTION
Version 4.1.3 includes a fix for a CSS grid issue: https://github.com/jakubpawlowicz/clean-css/issues/946